### PR TITLE
:memo: Update to new cron syntax

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -181,4 +181,5 @@ crons:
      # Run TYPO3's Scheduler tasks every 5 minutes.
     typo3:
         spec: "*/5 * * * *"
-        cmd: "vendor/bin/typo3 scheduler:run"
+        commands:
+            start: "vendor/bin/typo3 scheduler:run"


### PR DESCRIPTION
From the new changes (see [blog post](https://platform.sh/blog/2022/reel-in-activities-announcing-cancellable-activities-and-crons/))